### PR TITLE
fix: add type="button" to AccordionItem to prevent form submission

### DIFF
--- a/src/lib/accordion/AccordionItem.svelte
+++ b/src/lib/accordion/AccordionItem.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <h2 class={base()}>
-  <button onclick={handleToggle} class={buttonClass} aria-expanded={open}>
+  <button type="button" onclick={handleToggle} class={buttonClass} aria-expanded={open}>
     {#if header}
       {@render header()}
       {#if open}


### PR DESCRIPTION
Fixes #1579

This PR adds `type="button"` to the toggle `<button>` in `AccordionItem.svelte`.

Without this attribute, the button defaults to `type="submit"`, which can cause forms to submit unexpectedly when the AccordionItem is used inside a `<form>`.

Adding `type="button"` prevents that issue.